### PR TITLE
Expose flash messages and CSRF tags to views via central page object

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.2.3"
 gem "puma"
 gem "dry-component", git: "https://github.com/timriley/dry-component", branch: "import-containers-for-import-module" # temporary
 gem "dry-web", git: "https://github.com/dry-rb/dry-web", branch: "master"
+gem "rack_csrf"
 gem "shotgun"
 
 # Database persistence

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack_csrf (2.5.0)
+      rack (>= 1.1.0)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -251,6 +253,7 @@ DEPENDENCIES
   pg
   pry-byebug
   puma
+  rack_csrf
   rom!
   rom-mapper!
   rom-repository!

--- a/apps/main/core/main/application.rb
+++ b/apps/main/core/main/application.rb
@@ -1,6 +1,8 @@
+require "rack/csrf"
 require "dry/web/application"
 require "either_result_matcher/either_extensions"
 require_relative "container"
+require "roda_plugins"
 
 module Main
   class Application < Dry::Web::Application
@@ -13,14 +15,19 @@ module Main
 
     use Rack::Session::Cookie, key: "app_prototype.session", secret: AppPrototype::Container.options.session_secret
 
-    plugin :indifferent_params
+    use Rack::Csrf, raise: true
+
     plugin :flash
+    plugin :view
+    plugin :page
+
+    def name
+      :main
+    end
 
     route do |r|
       r.root do
-        r.resolve "main.views.home" do |home|
-          home.()
-        end
+        r.view "home"
       end
 
       r.multi_route

--- a/apps/main/core/main/page.rb
+++ b/apps/main/core/main/page.rb
@@ -1,26 +1,6 @@
-require "app_prototype/assets"
+require "app_prototype/page"
 
 module Main
-  # This is our main layout context that we inject into view
-  #
-  # Methods available in this object will be available in the main layout
-  class Page
-    attr_reader :options
-
-    def initialize(options = {})
-      @options = options
-    end
-
-    def assets
-      self[:assets]
-    end
-
-    def with(new_options)
-      self.class.new(options.merge(new_options))
-    end
-
-    def [](name)
-      options.fetch(name)
-    end
+  class Page < AppPrototype::Page
   end
 end

--- a/apps/main/core/main/view.rb
+++ b/apps/main/core/main/view.rb
@@ -15,9 +15,8 @@ module Main
     setting :formats, {html: :slim}
     setting :name, "application"
 
-    # Example of alternative layouts
-    # class Admin < View
-    #   setting :name, "admin"
-    # end
+    def locals(options)
+      super.merge(options[:scope].view_locals)
+    end
   end
 end

--- a/apps/main/web/templates/layouts/application.html.slim
+++ b/apps/main/web/templates/layouts/application.html.slim
@@ -4,4 +4,5 @@ html
     link rel="stylesheet" type="text/css" href=page.assets["public.css"]
     script type="text/javascript" src=page.assets["public.js"]
   body
+    == page.flash
     == yield

--- a/apps/main/web/templates/layouts/shared/_flash.html.slim
+++ b/apps/main/web/templates/layouts/shared/_flash.html.slim
@@ -1,0 +1,8 @@
+- if page.flash?
+  .flash
+    - if page.flash[:notice]
+      .notice
+        p = page.flash[:notice]
+    - if page.flash[:alert]
+      .alert
+        p = page.flash[:alert]

--- a/lib/app_prototype/page.rb
+++ b/lib/app_prototype/page.rb
@@ -1,0 +1,45 @@
+module AppPrototype
+  class Page
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
+
+    def view_locals
+      {csrf_tag: csrf_tag}
+    end
+
+    def csrf_metatag
+      self[:csrf_metatag].()
+    end
+
+    def csrf_tag
+      self[:csrf_tag].()
+    end
+
+    def assets
+      self[:assets]
+    end
+
+    def flash
+      self[:flash]
+    end
+
+    def flash?
+      %w(notice alert).any? { |type| flash[type] }
+    end
+
+    def with_flash(flash)
+      with(flash: flash)
+    end
+
+    def with(new_options)
+      self.class.new(options.merge(new_options))
+    end
+
+    def [](name)
+      options.fetch(name)
+    end
+  end
+end

--- a/lib/roda_plugins.rb
+++ b/lib/roda_plugins.rb
@@ -1,0 +1,33 @@
+require "roda"
+require "rack/csrf"
+
+class Roda
+  module RodaPlugins
+    module Page
+      module InstanceMethods
+        def current_page
+          page.with_flash(flash)
+        end
+
+        def page
+          self.class["page"].with(
+            csrf_metatag: -> { Rack::Csrf.metatag(request.env) },
+            csrf_tag: -> { Rack::Csrf.tag(request.env) }
+          )
+        end
+      end
+    end
+
+    module View
+      module RequestMethods
+        def view(name, overrides = {})
+          options = {scope: scope.current_page}.merge(overrides)
+          is(to: "#{scope.name}.views.#{name}", call_with: [options])
+        end
+      end
+    end
+
+    register_plugin :page, Page
+    register_plugin :view, View
+  end
+end


### PR DESCRIPTION
Add Roda plugins to make populating this page object from the routes files easy.

Resolves #31, resolves #2, resolves #3, resolves #28 
