### PR TITLE
Respond with 404/500 error pages when not in development

### DIFF
--- a/apps/main/core/main/application.rb
+++ b/apps/main/core/main/application.rb
@@ -36,7 +36,7 @@ module Main
     end
 
     error do |e|
-      if ENV["RACK_ENV"] == "production"
+      if ENV["RACK_ENV"] != "development"
         if e.is_a?(ROM::TupleCountMismatchError)
           response.status = 404
           self.class["main.views.errors.error_404"].(scope: current_page)


### PR DESCRIPTION
This PR allows us to show 404 and 500 pages in the test and production environments, meaning we can reliably ensure we see the correct error page with our automated tests.
