### PR TITLE
Fix postmark link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It uses:
 It also integrates with these 3rd party services:
 
 * [Bugsnag][bugsnag] for error reporting
-* [Postmark][bugsnag] for email deliveries
+* [Postmark][postmark] for email deliveries
 
 [bugsnag]: https://bugsnag.com
 [dry-transaction]:  http://dry-rb.org/gems/dry-transaction


### PR DESCRIPTION
It was pointed to bugsnag rather than postmark
