### PR TITLE
Expect that `flash` hash  has symbols as keys, not strings

### DIFF
--- a/lib/app_prototype/page.rb
+++ b/lib/app_prototype/page.rb
@@ -27,7 +27,7 @@ module AppPrototype
     end
 
     def flash?
-      %w(notice alert).any? { |type| flash[type] }
+      %i(notice alert).any? { |type| flash[type] }
     end
 
     def with_flash(flash)


### PR DESCRIPTION
Besides that in the most cases we assign flash messages using symbols, not strings, (flash partial)[/apps/main/web/templates/layouts/shared/_flash.html.slim] itself expects to see keys as symbols and will not display anything...