### PR TITLE
Add in task to load a DB structure from db/structure.sql

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,17 @@ namespace :db do
         file.write dump
       end
     end
+
+    desc "Load database structure from db/structure.sql"
+    task :load do
+      raise if ENV["RACK_ENV"] == "production"
+      require "uri"
+      uri = URI(DB.url)
+      db_name = uri.path.tr("/", "")
+      system "dropdb #{db_name}"
+      system "createdb #{db_name}"
+      system "psql -d #{db_name} -h localhost < db/structure.sql"
+    end
   end
 
   task :check_migrations_exist do


### PR DESCRIPTION
This PR adds a rake task to load in a database' structure via `rake db:structure:load`.

At the moment it's set to fail if `RACK["env"] == "production"`

This should address #1 