### PR TITLE
[WIP] Add routes rake task to display annotated routes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "postmark"
 group :development, :test do
   gem "guard-rspec", require: false
   gem "pry-byebug"
+  gem "roda-route_list"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
     roda (2.18.0)
       rack
     roda-flow (0.3.0)
+    roda-route_list (2.0.0)
+      roda
     rom (2.0.0)
       concurrent-ruby (~> 1.0)
       dry-equalizer (~> 0.2)
@@ -239,6 +241,7 @@ DEPENDENCIES
   que
   rack_csrf
   rake
+  roda-route_list
   rom
   rom-mapper
   rom-repository

--- a/Rakefile
+++ b/Rakefile
@@ -105,17 +105,23 @@ task :routes do
   require "roda"
   @app = Class.new(Roda)
 
+  # get a list of route files for all our apps
   app_paths = Pathname(__FILE__).join("../apps").realpath.join("*")
   routes = Dir.glob("#{app_paths}/web/routes/*.rb").join(" ")
   system("roda-parse_routes -f routes.json #{routes}")
 
+  # load the route_list plugin
   @app.plugin :route_list
   routes = @app.route_list
+
+  # determine the max lengths of our output strings so we can display a nice list of routes
   header_lengths = ["Name", "Methods", "URI Pattern"].map(&:length)
   name_width, methods_width, path_width = widths(routes).zip(header_lengths).map(&:max)
 
+  # print a header
   puts "#{"Name".rjust(name_width)} #{"Methods".ljust(methods_width)} #{"Path".ljust(path_width)}"
 
+  # print each of the routes
   routes.map do |r|
     puts "#{r[:name].to_s.rjust(name_width)} #{r[:methods].join(", ").ljust(methods_width)} #{r[:path].ljust(path_width)}"
   end

--- a/apps/main/web/routes/example.rb
+++ b/apps/main/web/routes/example.rb
@@ -1,5 +1,6 @@
 module Main
   class Application
+    # route[example_route]: GET /example
     route "example" do |r|
       # Routes go here
     end


### PR DESCRIPTION
This PR adds in a rake task to render out a list of annotated routes using [roda-route_list](https://github.com/jeremyevans/roda-route_list).

The task itself currently does a number of things and I have left it as a single procedure so we can discuss what is happening without having to look in multiple places.

Example annotation:
`# route[optional_name]: GET|POST /segment/:param`

Example output:
```
              Name Methods   Path
             admin GET, POST /admin
     example_route GET       /example
        blog_posts GET       /posts
         blog_post GET       /posts/:id
blog_post_comments GET       /posts/:id/comments
```